### PR TITLE
introduce primary language support for code fences

### DIFF
--- a/docs/language/basics.md
+++ b/docs/language/basics.md
@@ -204,7 +204,7 @@ line continuations connect code to lines to markdown lines
 
 ```markdown
             foo =\
-            \
+
 line continuations assign this string to `foo`
 ```
 
@@ -273,4 +273,26 @@ urls = [url.lstrip("*").lstrip() for url in
 * https://google.com"""
 
     .splitlines()]
+```
+
+*******************************************************
+
+by default doctests are not included in code.
+
+```markdown
+>>> this is a blockquote
+... with a trailing paragraph
+and is not a doctest
+
+    >>> assert 'this is a doctest\
+    ... because it is indented'
+```
+
+```python
+""">>> this is a blockquote
+... with a trailing paragraph
+and is not a doctest
+
+    >>> assert \'this is a doctest\
+    ... because it is indented\'""";
 ```

--- a/docs/language/basics.md
+++ b/docs/language/basics.md
@@ -260,7 +260,7 @@ requests.get(
 as parameters, markdown blocks can be manipulated with python
 
 ```markdown
-    urls = [ url.lstrip("*").lstrip() for url in 
+    urls = [url.lstrip("*").lstrip() for url in 
 * https://api.github.com
 * https://google.com
 

--- a/docs/language/container_blocks.md
+++ b/docs/language/container_blocks.md
@@ -1,0 +1,74 @@
+## transpiling in container blocks
+
+blocks and lists make up [commonmark's container blocks](https://spec.commonmark.org/0.30/#container-blocks).
+
+lists are probably one of the most confusing syntactic features of midgy.
+
+ 
+*******************************************************
+
+lists are strings
+
+```markdown
+* list item 1
+* list item 2
+```
+        
+```python
+"""* list item 1
+* list item 2""";
+```
+
+
+*******************************************************
+
+indented code requires and extra indents
+
+```markdown
+* list item 1
+
+        code block
+* list item 2
+    
+    list paragraph
+```
+        
+```python
+"""* list item 1"""
+
+code block
+"""* list item 2
+    
+    list paragraph""";
+```
+
+
+*******************************************************
+
+each level requires and extra code indent
+
+```markdown
+* list item 1
+
+        code block
+    * nested list item 1
+
+            code block
+    * nested list item 2
+        
+        list paragraph
+```
+        
+```python
+"""* list item 1"""
+
+code block
+"""    * nested list item 1"""
+
+    code block
+    """    * nested list item 2
+        
+        list paragraph""";
+```
+
+

--- a/docs/language/doctest.md
+++ b/docs/language/doctest.md
@@ -1,49 +1,62 @@
++++
+py.include_doctest = true
+py.include_indented_code = false
++++
+
 # doctest
 
-*******************************************************
-
-by default doctests are not included in code.
-
-```markdown
->>> this is a blockquote
-... with a trailing paragraph
-and is not a doctest
-
-    >>> assert 'this is a doctest\
-    ... because it is indented'
-```
-
-```python
-""">>> this is a blockquote
-... with a trailing paragraph
-and is not a doctest
-
-    >>> assert \'this is a doctest\
-    ... because it is indented\'""";
-```
 
 *******************************************************
 
 `include_doctest` flag includes doctest inputs in code
 
 ```markdown
-+++
-[py]
-include_doctest = true
-include_front_matter = false
-+++
-
     >>> print("a doctest")
+    a doctest
 ```
 
 ```python
-# +++
-# [py]
-# include_doctest = true
-# include_front_matter = false
-# +++
+print("a doctest")
+# a doctest
+```
+*******************************************************
+
+doctests can contain magics
+
+```markdown
+    >>> %%python
+    ... print("a doctest")
+    a doctest
+```
+
+```python
+get_ipython().run_cell_magic('python', '',
+"""print("a doctest")""")
+# a doctest
+```
+
+*******************************************************
+
+doctests can contain magics
+
+```markdown
++++
+py.include_indented_code = true
++++
+    "normal code and doctest code are separated"
+
+    >>> print("a doctest")
+    a doctest
+```
+
+```python
+locals().update(__import__("midgy").front_matter.load("""+++
+py.include_indented_code = true
++++"""))
+"normal code and doctest code are separated"
 
 print("a doctest")
+# a doctest
 ```
 
 ----------------------------------------------------------

--- a/docs/language/flags.md
+++ b/docs/language/flags.md
@@ -26,6 +26,25 @@ py.include_indented_code = false
 """    ignored""";
 ```
 
+
+*******************************************************
+
+markdown code can be ignored
+
+```markdown
++++
+py.include_markdown = false
++++
+ignored
+```
+
+```python
+locals().update(__import__("midgy").front_matter.load("""+++
+py.include_markdown = false
++++"""))
+# ignored
+```
+
 *******************************************************
 
 front matter code can be ignored

--- a/docs/language/line_continuations.md
+++ b/docs/language/line_continuations.md
@@ -16,7 +16,7 @@ a markdown paragraph can continues\
 ```python
 """a markdown paragraph can continues"""\
 \
-\
+        \
 .upper()
 ```
 

--- a/docs/language/line_continuations.md
+++ b/docs/language/line_continuations.md
@@ -16,7 +16,7 @@ a markdown paragraph can continues\
 ```python
 """a markdown paragraph can continues"""\
 \
-        \
+\
 .upper()
 ```
 

--- a/docs/language/magics.md
+++ b/docs/language/magics.md
@@ -73,3 +73,5 @@ get_ipython().run_cell_magic('magic', 'arguments', # ```
 """the body""") 
 # ```
 ````
+
+this form is not friendly in native markdown mode

--- a/docs/language/magics.md
+++ b/docs/language/magics.md
@@ -1,0 +1,75 @@
++++
+py.include_doctest = true
++++
+
+
+# `midgy` and magics
+
+cell magics only built in to the language as they provide macro features for code.
+
+
+*******************************************************
+
+magics can be in indented code
+
+```markdown
+%%magic arguments
+the body of the cell magic
+is quoted and indents are maintained
+```
+
+```python
+get_ipython().run_cell_magic('magic', 'arguments',
+"""the body of the cell magic
+is quoted and indents are maintained""")
+```
+
+*******************************************************
+
+magics can be in code fences
+
+````markdown
+```ipython
+%%magic arguments 
+the body 
+```
+````
+
+````python
+# ```ipython
+get_ipython().run_cell_magic('magic', 'arguments', 
+"""the body""") 
+# ```
+````
+
+*******************************************************
+
+magics can be in doctests
+
+````markdown
+    >>> %%magic arguments 
+    ... the body 
+    some output
+````
+
+````python
+get_ipython().run_cell_magic('magic', 'arguments', 
+"""the body""") 
+# some output
+````
+
+*******************************************************
+
+magics can exist in the fence info
+
+````markdown
+```%%magic arguments 
+the body 
+```
+````
+
+````python
+get_ipython().run_cell_magic('magic', 'arguments', # ``` 
+"""the body""") 
+# ```
+````

--- a/docs/language/mixed.md
+++ b/docs/language/mixed.md
@@ -1,0 +1,56 @@
+## mixing code fences and indented code
+
+it is possible mix multiple flavors of code inputs with `midgy`.
+this document demonstrates the implications of mixing
+__indented code__, __code fences__, and __doctests__ inputs.
+
+generally, it is suspected that an author or document will
+choose one mode for code input and stick to it. what follows
+are some of the outcomes of this choice.
+
+*******************************************************
+
+code fences are offset 4 spaces from indented code
+
+````markdown
+    print("indented code")
+```python
+print("fenced code")
+```
+````
+
+````python
+    print("indented code")
+# ```python
+print("fenced code")
+# ```
+````
+
+the offset of four is defined because of the [indented code block commonmark specification].
+
+*******************************************************
+
+
+````markdown
+    def an_indented_code_function():
+```python
+    print("encapsulated in the function")
+```
+```python
+print("NOT encapsulated in the function")
+```
+````
+
+````python
+def an_indented_code_function():
+    # ```python
+    print("encapsulated in the function")
+    # ```
+# ```python
+print("NOT encapsulated in the function")
+# ```
+````
+
+because of the offset, the code fence needs to be indented to exist within the function defition.
+
+[indented code block commonmark specification]: https://spec.commonmark.org/0.30/#indented-code-blocks

--- a/docs/language/test_language.py
+++ b/docs/language/test_language.py
@@ -27,7 +27,7 @@ def gen_tests():
                 continue
 
             name, i, o = None, None, None
-            env = parser._init_env(cell, tokens)
+            env = parser.get_initial_env(cell, tokens)
             for n, token in enumerate(tokens):
                 if token.type == "fence":
                     if token.info == "markdown":

--- a/src/midgy/__init__.py
+++ b/src/midgy/__init__.py
@@ -1,2 +1,4 @@
 __all__ = "Python", "md_to_python"
-from .python import Python, md_to_python
+from .python import Python
+
+tangle = md_to_python = Python.code_from_string

--- a/src/midgy/lexers.py
+++ b/src/midgy/lexers.py
@@ -1,9 +1,11 @@
 from re import compile
+
 BLOCK, FENCE, PYCON = "code_block", "fence", "pycon"
 DOCTEST_CHARS = 62, 62, 62, 32  # >>>S
 ELLIPSIS_CHARS = (ord("."),) * 3 + (32,)
 MAGIC_CHARS = (37, 37)  # %%
-MAGIC= compile("^\s*%{2}\S+")
+MAGIC = compile("^\s*%{2}\S+")
+
 
 def code_lexer(state, start, end, silent=False):
     """a code lexer that tracks indents in the token and is aware of doctests"""
@@ -88,7 +90,7 @@ def doctest_lexer(state, startLine, end, silent=False):
             is_magic=bool(MAGIC.match(token.content.lstrip().lstrip(">").lstrip())),
             is_doctest=True,
             input=[lead, extra],
-            output=[extra, output] if extra < output else None
+            output=[extra, output] if extra < output else None,
         )
         return True
     return False
@@ -107,6 +109,7 @@ def code_fence_lexer(state, *args, **kwargs):
                 first_indent = state.sCount[next]
             last_indent = state.sCount[next]
         min_indent = min([state.sCount[i] for i in extent if not state.isEmpty(i)] or [0])
+
         token.meta.update(
             first_indent=first_indent or 0,
             last_indent=last_indent,

--- a/src/midgy/lexers.py
+++ b/src/midgy/lexers.py
@@ -114,6 +114,7 @@ def code_fence_lexer(state, *args, **kwargs):
             first_indent=first_indent or 0,
             last_indent=last_indent,
             min_indent=min_indent,
+            is_magic_info=bool(MAGIC.match(token.info)),
             is_magic=bool(MAGIC.match(token.content)),
             is_doctest=token.info == PYCON,
         )

--- a/src/midgy/lexers.py
+++ b/src/midgy/lexers.py
@@ -1,0 +1,117 @@
+from re import compile
+BLOCK, FENCE, PYCON = "code_block", "fence", "pycon"
+DOCTEST_CHARS = 62, 62, 62, 32  # >>>S
+ELLIPSIS_CHARS = (ord("."),) * 3 + (32,)
+MAGIC_CHARS = (37, 37)  # %%
+MAGIC= compile("^\s*%{2}\S+")
+
+def code_lexer(state, start, end, silent=False):
+    """a code lexer that tracks indents in the token and is aware of doctests"""
+    is_magic, min_indent = None, 9999
+    if state.sCount[start] - state.blkIndent >= 4:
+        first_indent, last_indent, next, last_line = 0, 0, start, start
+        while next < end:
+            if state.isEmpty(next):
+                next += 1
+                continue
+            if state.sCount[next] - state.blkIndent >= 4:
+                begin = state.bMarks[next] + state.tShift[next]
+                if is_magic is None:
+                    is_magic = state.srcCharCode[begin : begin + 2] == MAGIC_CHARS
+                if not is_magic and state.srcCharCode[begin : begin + 4] == DOCTEST_CHARS:
+                    break
+                if not first_indent:
+                    first_indent = state.sCount[next]
+                min_indent = min(min_indent, state.sCount[next])
+                last_indent, last_line = state.sCount[next], next
+                next += 1
+            else:
+                break
+        state.line = last_line + 1
+        token = state.push(BLOCK, "code", 0)
+        token.content = state.getLines(start, state.line, 4 + state.blkIndent, True)
+        token.map = [start, state.line]
+        token.meta.update(
+            first_indent=first_indent,
+            last_indent=last_indent,
+            min_indent=min_indent,
+            is_magic=is_magic,
+            is_doctest=False,
+        )
+        return True
+    return False
+
+
+def doctest_lexer(state, startLine, end, silent=False):
+    """a markdown-it-py plugin for doctests
+
+    doctest are a literate programming convention in python that we
+    include in the pidgy grammar. this avoids a mixing python and doctest
+    code together.
+
+    the doctest blocks:
+    * extend the indented code blocks
+    * do not conflict with blockquotes
+    * are implicit code fences with the `pycon` info
+    * can be replaced with explicit code blocks.
+    """
+    start = state.bMarks[startLine] + state.tShift[startLine]
+
+    if (state.sCount[startLine] - state.blkIndent) < 4:
+        return False
+
+    if state.srcCharCode[start : start + 4] == DOCTEST_CHARS:
+        lead, extra, output, closed = startLine, startLine + 1, startLine + 1, False
+        indent, next, magic = state.sCount[startLine], startLine + 1, None
+        while next < end:
+            if state.isEmpty(next):
+                break
+            if state.sCount[next] < indent:
+                break
+            begin = state.bMarks[next] + state.tShift[next]
+            if state.srcCharCode[begin : begin + 4] == DOCTEST_CHARS:
+                break
+            next += 1
+            if (not closed) and state.srcCharCode[begin : begin + 4] == ELLIPSIS_CHARS:
+                extra = next
+            else:
+                closed = True
+                output = next
+        state.line = next
+        token = state.push(BLOCK, "code", 0)
+        token.content = state.getLines(startLine, next, 0, True)
+        token.map = [startLine, state.line]
+        token.meta.update(
+            first_indent=indent,
+            last_indent=indent,
+            min_indent=indent,
+            is_magic=bool(MAGIC.match(token.content.lstrip().lstrip(">").lstrip())),
+            is_doctest=True,
+            input=[lead, extra],
+            output=[extra, output] if extra < output else None
+        )
+        return True
+    return False
+
+
+def code_fence_lexer(state, *args, **kwargs):
+    from markdown_it.rules_block.fence import fence
+
+    result = fence(state, *args, **kwargs)
+    if result:
+        token = state.tokens[-1]
+        first_indent, last_indent = None, 0
+        extent = range(token.map[0] + 1, token.map[1] - 1)
+        for next in extent:
+            if first_indent is None:
+                first_indent = state.sCount[next]
+            last_indent = state.sCount[next]
+        min_indent = min([state.sCount[i] for i in extent if not state.isEmpty(i)] or [0])
+        token.meta.update(
+            first_indent=first_indent or 0,
+            last_indent=last_indent,
+            min_indent=min_indent,
+            is_magic=bool(MAGIC.match(token.content)),
+            is_doctest=token.info == PYCON,
+        )
+    return result

--- a/src/midgy/python.py
+++ b/src/midgy/python.py
@@ -1,9 +1,12 @@
 """the Python class that translates markdown to python code"""
 from dataclasses import dataclass, field
 from io import StringIO
+from copy import copy
+from functools import partial
 from .render import Renderer, escape, FENCE, SP, QUOTES
 from .lexers import MAGIC
-
+from typing import Tuple
+DEFAULT_FENCE_LANGS = "python", "ipython"
 
 @dataclass
 class Python(Renderer):
@@ -18,7 +21,7 @@ class Python(Renderer):
     # include markdown in that code as strings, (False) uses comments
     include_markdown: bool = True
     # code fence languages that indicate a code block
-    include_code_fences: list = field(default_factory=["python", "ipython"].copy)
+    include_code_fences: Tuple[str] = field(default_factory=partial(copy, DEFAULT_FENCE_LANGS))
     include_magic: bool = True
 
     front_matter_loader = '__import__("midgy").front_matter.load'
@@ -82,6 +85,8 @@ class Python(Renderer):
             
             if token.meta["is_magic_info"]:
                 return self._fence_info_magic(token, env)
+
+    # def _flush_magic(self):
 
     def _fence_info_magic(self, token, env):
         """return a modified code fence that identifies as code"""

--- a/src/midgy/render.py
+++ b/src/midgy/render.py
@@ -44,14 +44,6 @@ class Renderer:
         """render a string"""
         return cls(**kwargs).render(body)
 
-    def fence(self, token, env):
-        """the fence renderer is pluggable.
-
-        if token_{token.info} exists then that method is called to render the token"""
-        method = getattr(self, f"fence_{token.info}", None)
-        if method:
-            return method(token, env)
-
     def get_block(self, env, stop=None):
         """iterate through the lines in a buffer"""
         if stop is None:
@@ -163,10 +155,6 @@ class Renderer:
             prior_token and block.insert(0, prior_token)
             yield self.render_tokens(block, env=env, stop=next_token)
             prior, prior_token = env, next_token
-
-    def render_lines(self, src):
-        # use py the ipython transformer
-        return self.render("".join(src)).splitlines(True)
 
     def render_token(self, token, env):
         if token:

--- a/src/midgy/render.py
+++ b/src/midgy/render.py
@@ -8,14 +8,11 @@ from re import compile
 __all__ = ()
 
 DOCTEST_CHAR, CONTINUATION_CHAR, COLON_CHAR, QUOTES_CHARS = 62, 92, 58, {39, 34}
-DOCTEST_CHARS = DOCTEST_CHAR, DOCTEST_CHAR, DOCTEST_CHAR, 32
 BLOCK, FENCE, PYCON = "code_block", "fence", "pycon"
 ESCAPE = {x: "\\" + x for x in "'\""}
 ESCAPE_PATTERN = compile("[" + "".join(ESCAPE) + "]")
-ELLIPSIS_CHARS = (ord("."),) * 3 + (32,)
 escape = partial(ESCAPE_PATTERN.sub, lambda m: ESCAPE.get(m.group(0)))
 SP, QUOTES = chr(32), (chr(34) * 3, chr(39) * 3)
-MAGIC = compile("^\s*%{2}\S+")
 
 
 # the Renderer is special markdown renderer designed to produce
@@ -42,35 +39,6 @@ class Renderer:
     def __post_init__(self):
         self.parser = self.get_parser()
 
-    def get_parser(self):
-        from markdown_it import MarkdownIt
-
-        parser = MarkdownIt("gfm-like", options_update=dict(inline_definitions=True, langPrefix=""))
-        return self.set_parser_defaults(parser)
-
-    def set_parser_defaults(self, parser):
-        # our tangling system adds extra conventions to commonmark:
-        ## extend indented code to recognize doctest syntax in-line
-        ## replace the indented code lexer to recognize doctests and append metadata.
-        ## recognize shebang lines at the beginning of a document.
-        ## recognize front-matter at the beginning of document of following shebangs
-        from mdit_py_plugins import deflist, footnote
-        from .front_matter import _front_matter_lexer, _shebang_lexer
-
-        parser.block.ruler.before("code", "doctest", _doctest_lexer)
-        parser.block.ruler.disable("code")
-        # our indented code captures doctests in indented blocks
-        parser.block.ruler.after("doctest", "code", _code_lexer)
-        parser.disable(FENCE)
-        # our code fence captures indent information
-        parser.block.ruler.after("code", FENCE, code_fence)
-        # shebang because this markdown is code
-        parser.block.ruler.before("table", "shebang", _shebang_lexer)
-        parser.block.ruler.before("table", "front_matter", _front_matter_lexer)
-        parser.use(footnote.footnote_plugin).use(deflist.deflist_plugin)
-        parser.disable("footnote_tail")
-        return parser
-
     def code_block(self, token, env):
         yield from self.get_block(env, token.map[1])
 
@@ -95,111 +63,7 @@ class Renderer:
             while env["last_line"] < stop:
                 yield self.readline(env)
 
-    def get_updated_env(self, token, env):
-        """update the state of the environment"""
-        left = token.content.rstrip()
-        continued = left.endswith("\\")
-        env.update(
-            colon_block=left.endswith(":"), quoted_block=left.endswith(QUOTES), continued=continued
-        )
-
-    def non_code(self, env, next=None):
-        yield from self.get_block(env, next.map[0] if next else None)
-        if next:
-            env.update(last_indent=next.meta.get("last_indent", 0))
-
-    def parse(self, src):
-        return self.parser.parse(src)
-
-    def parse_cells(self, body, *, include_hr=True):
-        yield from (x[0] for x in self.walk_cells(self.parse(body), include_hr=include_hr))
-
-    def print(self, iter, io):
-        return print(*iter, file=io, sep="", end="")
-
-    def readline(self, env):
-        try:
-            return env["source"].readline()
-        finally:
-            env["last_line"] += 1
-
-    def render(self, src):
-        return self.render_tokens(self.parse(src), src=src)
-
-    def render_cells(self, src, *, include_hr=True):
-        tokens = self.parse(src)
-        self = self.renderer_from_tokens(tokens)
-        prior = self.get_initial_env(src, tokens)
-        prior_token = None
-        source = prior.pop("source")
-
-        for block, next_token in self.walk_cells(tokens, env=prior, include_hr=include_hr):
-            env = self.get_initial_env(src, block)
-            env["source"], env["last_line"] = source, prior["last_line"]
-            prior_token and block.insert(0, prior_token)
-            yield self.render_tokens(block, env=env, stop=next_token)
-            prior, prior_token = env, next_token
-
-    def render_lines(self, src):
-        return self.render("".join(src)).splitlines(True)
-
-    def renderer_from_tokens(self, tokens):
-        front_matter = self.get_front_matter(tokens)
-        if front_matter:
-            # front matter can reconfigure the parser and make a new one
-            config = front_matter.get(self.config_key, None)
-            if config:
-                return type(self)(**config)
-        return self
-
-    def render_token(self, token, env):
-        if token:
-            method = getattr(self, token.type, None)
-            if method:
-                yield from method(token, env) or ()
-
-    def render_tokens(self, tokens, env=None, src=None, stop=None, target=None):
-        """render parsed markdown tokens"""
-        if target is None:
-            target = StringIO()
-        self = self.renderer_from_tokens(tokens)
-        if env is None:
-            env = self.get_initial_env(src, tokens)
-        for generic, code in self.walk_code_blocks(tokens):
-            # we walk pairs of tokens preceding code and the code token
-            # the next code token is needed as a reference for indenting
-            # non-code blocks that precede the code.
-            env["next_code"] = code
-            for token in generic + [code]:
-                self.print(self.render_token(token, env), target)
-        # handle anything left in the buffer
-        self.print(self.non_code(env, stop), target)
-        return target.getvalue()  # return the value of the target, a format string.
-
-    def get_initial_env(self, src, tokens):
-        """initialize the parser environment
-
-        peek into the tokens looking for the first code token identified."""
-        env = dict(source=StringIO(src), last_line=0, last_indent=0)
-        for token in tokens:  # iterate through the tokens
-            if self.is_code_block(token):
-                env["min_indent"] = min(
-                    env.setdefault("min_indent", 9999), token.meta["min_indent"]
-                )
-        env.setdefault("min_indent", 0)
-        return env
-
-    def get_front_matter(self, tokens):
-        for token in tokens:
-            if token.type == "shebang":
-                continue
-            if token.type == "front_matter":
-                from .front_matter import load
-
-                return load(token.content)
-            return
-
-    def walk_cells(self, tokens, *, env=None, include_hr=True):
+    def get_cells(self, tokens, *, env=None, include_hr=True):
         """walk cells separated by mega-hrs"""
         block = []
         for token in tokens:
@@ -216,144 +80,150 @@ class Renderer:
         if block:
             yield block, None
 
-    def is_code_fence(self, token):
-        return token.type == FENCE and token.type in self.include_code_fences
+    def get_front_matter(self, tokens):
+        for token in tokens:
+            if token.type == "shebang":
+                continue
+            if token.type == "front_matter":
+                from .front_matter import load
+
+                return load(token.content)
+            return
+
+    def get_initial_env(self, src, tokens):
+        """initialize the parser environment
+
+        peek into the tokens looking for the first code token identified."""
+        env = dict(source=StringIO(src), last_line=0, last_indent=0)
+        for token in tokens:  # iterate through the tokens
+            if self.is_code_block(token):
+                env["min_indent"] = min(
+                    env.setdefault("min_indent", 9999), token.meta["min_indent"]
+                )
+        env.setdefault("min_indent", 0)
+        return env
+
+    def get_parser(self):
+        from markdown_it import MarkdownIt
+
+        parser = MarkdownIt("gfm-like", options_update=dict(inline_definitions=True, langPrefix=""))
+        return self.set_parser_defaults(parser)
+
+    def get_updated_env(self, token, env, **kwargs):
+        """update the state of the environment"""
+        left = token.content.rstrip()
+        continued = left.endswith("\\")
+        colon_block = left.endswith(":")
+        quoted_block = left.endswith(QUOTES)
+        env.update(
+            colon_block=colon_block, quoted_block=quoted_block, continued=continued, **kwargs
+        )
 
     def is_code_block(self, token):
         """is the token a code block entry"""
         if self.include_indented_code and token.type == BLOCK:
+            if token.meta["is_doctest"]:
+                return self.include_doctest
             return True
         elif token.type == FENCE:
             if token.info in self.include_code_fences:
                 return True
-            if self.include_doctest and token.info == PYCON:
-                return True
+            if token.info == PYCON:
+                return self.include_doctest
         return False
 
-    def walk_code_blocks(self, tokens):
-        """separate non code blocks and blocks
+    def non_code(self, env, next=None):
+        yield from self.get_block(env, next.map[0] if next else None)
+        if next:
+            env.update(last_indent=next.meta.get("last_indent", 0))
 
-        a pair of non-code/code blocks are yield when indented code is discovered."""
-        prior = []
+    def parse(self, src):
+        return self.parser.parse(src)
+
+    def parse_cells(self, body, *, include_hr=True):
+        yield from (x[0] for x in self.get_cells(self.parse(body), include_hr=include_hr))
+
+    def print(self, iter, io):
+        return print(*iter, file=io, sep="", end="")
+
+    def readline(self, env):
+        try:
+            return env["source"].readline()
+        finally:
+            env["last_line"] += 1
+
+    def render(self, src):
+        return self.render_tokens(self.parse(src), src=src)
+
+    def render_cells(self, src, *, include_hr=True):
+        # cells allow different parsers in a single pass
+        tokens = self.parse(src)
+        self = self.renderer_from_tokens(tokens)
+        prior = self.get_initial_env(src, tokens)
+        prior_token = None
+        source = prior.pop("source")
+
+        for block, next_token in self.get_cells(tokens, env=prior, include_hr=include_hr):
+            env = self.get_initial_env(src, block)
+            env["source"], env["last_line"] = source, prior["last_line"]
+            prior_token and block.insert(0, prior_token)
+            yield self.render_tokens(block, env=env, stop=next_token)
+            prior, prior_token = env, next_token
+
+    def render_lines(self, src):
+        # use py the ipython transformer
+        return self.render("".join(src)).splitlines(True)
+
+    def render_token(self, token, env):
+        if token:
+            method = getattr(self, token.type, None)
+            if method:
+                yield from method(token, env) or ()
+
+    def render_tokens(self, tokens, env=None, src=None, stop=None, target=None):
+        """render parsed markdown tokens"""
+        if target is None:
+            target = StringIO()
+        self = self.renderer_from_tokens(tokens)
+        if env is None:
+            env = self.get_initial_env(src, tokens)
         for token in tokens:
             if self.is_code_block(token):
-                yield list(prior), token
-                prior.clear()
-            else:
-                prior.append(token)
-        yield prior, None
+                env["next_code"] = token
+            self.print(self.render_token(token, env), target)
+        # handle anything left in the buffer
+        self.print(self.non_code(env, stop), target)
+        return target.getvalue()  # return the value of the target, a format string.
 
+    def renderer_from_tokens(self, tokens):
+        front_matter = self.get_front_matter(tokens)
+        if front_matter:
+            # front matter can reconfigure the parser and make a new one
+            config = front_matter.get(self.config_key, None)
+            if config:
+                return type(self)(**config)
+        return self
 
-def _code_lexer(state, start, end, silent=False):
-    """a code lexer that tracks indents in the token and is aware of doctests"""
-    if state.sCount[start] - state.blkIndent >= 4:
-        first_indent, last_indent, next, last_line = 0, 0, start, start
-        while next < end:
-            if state.isEmpty(next):
-                next += 1
-                continue
-            if state.sCount[next] - state.blkIndent >= 4:
-                begin = state.bMarks[next] + state.tShift[next]
-                if state.srcCharCode[begin : begin + 4] == DOCTEST_CHARS:
-                    break
-                if not first_indent:
-                    first_indent = state.sCount[next]
-                last_indent, last_line = state.sCount[next], next
-                next += 1
-            else:
-                break
-        state.line = last_line + 1
-        token = state.push(BLOCK, "code", 0)
-        token.content = state.getLines(start, state.line, 4 + state.blkIndent, True)
-        token.map = [start, state.line]
-        min_indent = min(
-            state.sCount[i]
-            for i in range(start, state.line)
-            if not state.isEmpty(i) and state.sCount[i]
-        )
-        meta = dict(
-            first_indent=first_indent,
-            last_indent=last_indent,
-            min_indent=min_indent,
-            magic=bool(MAGIC.match(token.content)),
-        )
-        token.meta.update(meta)
-        return True
-    return False
+    def set_parser_defaults(self, parser):
+        # our tangling system adds extra conventions to commonmark:
+        ## extend indented code to recognize doctest syntax in-line
+        ## replace the indented code lexer to recognize doctests and append metadata.
+        ## recognize shebang lines at the beginning of a document.
+        ## recognize front-matter at the beginning of document of following shebangs
+        from mdit_py_plugins import deflist, footnote
+        from .front_matter import _front_matter_lexer, _shebang_lexer
+        from .lexers import code_fence_lexer, doctest_lexer, code_lexer
 
-
-def _doctest_lexer(state, startLine, end, silent=False):
-    """a markdown-it-py plugin for doctests
-
-    doctest are a literate programming convention in python that we
-    include in the pidgy grammar. this avoids a mixing python and doctest
-    code together.
-
-    the doctest blocks:
-    * extend the indented code blocks
-    * do not conflict with blockquotes
-    * are implicit code fences with the `pycon` info
-    * can be replaced with explicit code blocks.
-    """
-    start = state.bMarks[startLine] + state.tShift[startLine]
-
-    if (state.sCount[startLine] - state.blkIndent) < 4:
-        return False
-
-    if state.srcCharCode[start : start + 4] == DOCTEST_CHARS:
-        lead, extra, output, closed = startLine, startLine + 1, startLine + 1, False
-        indent, next, magic = state.sCount[startLine], startLine + 1, None
-        while next < end:
-            if state.isEmpty(next):
-                break
-            if state.sCount[next] < indent:
-                break
-            begin = state.bMarks[next] + state.tShift[next]
-            if state.srcCharCode[begin : begin + 4] == DOCTEST_CHARS:
-                break
-
-            next += 1
-            if (not closed) and state.srcCharCode[begin : begin + 4] == ELLIPSIS_CHARS:
-                extra = next
-            else:
-                closed = True
-                output = next
-        state.line = next
-        token = state.push(FENCE, "code", 0)
-        token.info = PYCON
-        token.content = state.getLines(startLine, next, 0, True)
-        token.map = [startLine, state.line]
-        token.meta.update(
-            first_indent=indent,
-            last_indent=indent,
-            min_indent=indent,
-            magic=bool(MAGIC.match(token.content.lstrip().lstrip(">").lstrip())),
-        )
-        token.meta.update(input=[lead, extra])
-        token.meta.update(output=[extra, output] if extra < output else None)
-
-        return True
-    return False
-
-
-def code_fence(state, *args, **kwargs):
-    from markdown_it.rules_block.fence import fence
-
-    result = fence(state, *args, **kwargs)
-    if result:
-        token = state.tokens[-1]
-        first_indent, last_indent = None, 0
-        extent = range(token.map[0] + 1, token.map[1] - 1)
-        for next in extent:
-            if first_indent is None:
-                first_indent = state.sCount[next]
-            last_indent = state.sCount[next]
-        min_indent = min([state.sCount[i] for i in extent if not state.isEmpty(i)] or [0])
-
-        token.meta.update(
-            first_indent=first_indent or 0,
-            last_indent=last_indent,
-            min_indent=min_indent,
-            magic=bool(MAGIC.match(token.content)),
-        )
-    return result
+        parser.block.ruler.before("code", "doctest", doctest_lexer)
+        parser.block.ruler.disable("code")
+        # our indented code captures doctests in indented blocks
+        parser.block.ruler.after("doctest", "code", code_lexer)
+        parser.disable(FENCE)
+        # our code fence captures indent information
+        parser.block.ruler.after("code", FENCE, code_fence_lexer)
+        # shebang because this markdown is code
+        parser.block.ruler.before("table", "shebang", _shebang_lexer)
+        parser.block.ruler.before("table", "front_matter", _front_matter_lexer)
+        parser.use(footnote.footnote_plugin).use(deflist.deflist_plugin)
+        parser.disable("footnote_tail")
+        return parser

--- a/src/midgy/render.py
+++ b/src/midgy/render.py
@@ -31,6 +31,7 @@ class Renderer:
 
     parser: object = None
     cell_hr_length: int = 9
+    include_code: bool = True # the nuclear option
     include_code_fences: set = field(default_factory=set)
     include_indented_code: bool = True
     include_doctest: bool = False
@@ -107,15 +108,16 @@ class Renderer:
 
     def is_code_block(self, token):
         """is the token a code block entry"""
-        if token.type == BLOCK:
-            if token.meta["is_doctest"]:
-                return self.include_doctest
-            return self.include_indented_code
-        elif token.type == FENCE:
-            if token.info in self.include_code_fences:
-                return True
-            if token.info == PYCON:
-                return self.include_doctest
+        if self.include_code:
+            if token.type == BLOCK:
+                if token.meta["is_doctest"]:
+                    return self.include_doctest
+                return self.include_indented_code
+            elif token.type == FENCE:
+                if token.info in self.include_code_fences:
+                    return True
+                if token.info == PYCON:
+                    return self.include_doctest
         return False
 
     def non_code(self, env, next=None):

--- a/src/midgy/render.py
+++ b/src/midgy/render.py
@@ -86,10 +86,6 @@ class Renderer:
         if method:
             return method(token, env)
 
-    def format(self, body):
-        """a function that consumers can use to format their code"""
-        return body
-
     def get_block(self, env, stop=None):
         """iterate through the lines in a buffer"""
         if stop is None:
@@ -126,9 +122,8 @@ class Renderer:
         finally:
             env["last_line"] += 1
 
-    def render(self, src, format=False):
-        out = self.render_tokens(self.parse(src), src=src)
-        return self.format(out) if format else out
+    def render(self, src):
+        return self.render_tokens(self.parse(src), src=src)
 
     def render_cells(self, src, *, include_hr=True):
         tokens = self.parse(src)
@@ -219,6 +214,9 @@ class Renderer:
                 block.append(token)
         if block:
             yield block, None
+
+    def is_code_fence(self, token):
+        return token.type == "fence" and token.type in self.include_code_fences
 
     def is_code_block(self, token):
         """is the token a code block entry"""

--- a/src/midgy/render.py
+++ b/src/midgy/render.py
@@ -37,10 +37,7 @@ class Renderer:
     config_key: str = "py"
 
     def __post_init__(self):
-        self.parser = self.get_parseu()
-
-    def asdict(self):
-        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+        self.parser = self.get_parser()
 
     @classmethod
     def code_from_string(cls, body, **kwargs):
@@ -196,7 +193,7 @@ class Renderer:
         front_matter = self.get_front_matter(tokens)
         if front_matter:
             # front matter can reconfigure the parser and make a new one
-            config = self.asdict()
+            config = {k: getattr(self, k) for k in self.__dataclass_fields__}
             config.update(front_matter.get(self.config_key, {}))
             if config:
                 return type(self)(**config)


### PR DESCRIPTION
when i observe folks writing markdown they often use code fences.
this project started only thinking about indented code.
because of this natural tendency we are introducing code fences to the primary transpiler.

in `midgy` the primary language is python, so when python or ipython are found in code fences we include those blocks as code.
this addition demanded a more robust use of the cell magics too.

